### PR TITLE
Fix README: SDK dependency, typo, and protocol adapter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Anoma SDK exposes an API for developers to create applications in Elixir on
 top of Anoma. The SDK exposes the core data structures (e.g., `Transaction`) and
-their operationg (e.g., `prove`).
+their operations (e.g., `prove`).
 
 
 ## Repository Organisation
@@ -19,7 +19,7 @@ Add the repository as a dependency in your `mix.exs`.
 ```elixir
 defp deps do
   [
-    {:jason, git: "https://github.com/anoma/anoma-sdk"}
+    {:anoma_sdk, git: "https://github.com/anoma/anoma-sdk"}
   ]
 end
 ```
@@ -38,7 +38,7 @@ Here's a markdown table with the environment variables and their descriptions:
 | `BONSAI_API_URL`                   | Bonsai URL                                                          | URL         |
 | `BONSAI_API_KEY`                   | Authentication key for Bonsai API access                            | String      |
 
-To find the latest protocol adapter address, see here.
+To find the latest protocol adapter address, see [here](https://github.com/anoma/evm-protocol-adapter).
 
 > [!TIP]
 > If you want to try local development without actually submitting transactions to


### PR DESCRIPTION
1. Corrected dependency to `:anoma_sdk` (instead of `:jason`).  
2. Fixed typo: “operationg” → **“operations”**.  
3. Added proper link placeholder for the latest protocol adapter. 

CC @m1dnight @mariari 