### PR TITLE
Replace the binary type with <<_::256>>

### DIFF
--- a/lib/arm/datastructures/nullifier_key.ex
+++ b/lib/arm/datastructures/nullifier_key.ex
@@ -11,7 +11,7 @@ defmodule AnomaSDK.Arm.NullifierKey do
   The type of a nullifierkey.
   The length of a nullifier key is 32 bytes.
   """
-  @type t :: binary()
+  @type t :: <<_::256>>
 
   @doc """
   Generate a nullifier key with all zeros.

--- a/lib/arm/datastructures/nullifier_key_commitment.ex
+++ b/lib/arm/datastructures/nullifier_key_commitment.ex
@@ -8,5 +8,5 @@ defmodule AnomaSDK.Arm.NullifierKeyCommitment do
   The type of a nullifier key commitment.
   The length of the nullifier key commitment is 32 bytes.
   """
-  @type t :: binary()
+  @type t :: <<_::256>>
 end


### PR DESCRIPTION
The nullifier key is 32 bytes long, we should properly annotate the type since this is the precondition for the type.

This informs the validity check in future work