### PR TITLE
Make the Merklepath use the Leaf type

### DIFF
--- a/lib/arm/datastructures/merkle_path.ex
+++ b/lib/arm/datastructures/merkle_path.ex
@@ -4,7 +4,7 @@ defmodule AnomaSDK.Arm.MerklePath do
   """
   use TypedStruct
 
-  @type path_node :: {binary(), boolean()}
+  @type path_node :: {AnomaSDK.Arm.MerkleTree.leaf(), boolean()}
 
   @type t :: [path_node()]
 


### PR DESCRIPTION
The type of the path is a bunch of leaves, so this type was improperly noted before. It was fine due to these types being the same, but this is not robust when proper typing is had for the leaf, which does have a specific size