### PR TITLE
Change the Merkle Leaf size to a fixed size

### DIFF
--- a/lib/arm/datastructures/merkle_tree.ex
+++ b/lib/arm/datastructures/merkle_tree.ex
@@ -13,10 +13,10 @@ defmodule AnomaSDK.Arm.MerkleTree do
   @action_tree_depth 4
   @action_tree_max_leaves 1 <<< @action_tree_depth
 
-  @type leaf :: binary()
+  @type leaf :: <<_::256>>
 
   typedstruct do
-    field :leaves, [binary()]
+    field :leaves, [leaf()]
   end
 
   defimpl Jason.Encoder, for: AnomaSDK.Arm.MerkleTree do


### PR DESCRIPTION
In the Risc0 Implementation they pin it to WORD_SIZE which can be seen below:

pub const WORD_SIZE: usize = core::mem::size_of::<u32>();

In which they represent it as a vec of u32s.