### PR TITLE
Change the type from [byte()] to [byte()] | nil

### DIFF
--- a/lib/arm/arm.ex
+++ b/lib/arm/arm.ex
@@ -39,7 +39,7 @@ defmodule AnomaSDK.Arm do
   @doc """
   Decrypt a ciphertext using a private key and public key.
   """
-  @spec decrypt_cipher([byte()], Keypair.t()) :: [byte()]
+  @spec decrypt_cipher([byte()], Keypair.t()) :: [byte()] | nil
   def decrypt_cipher(_, _), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """


### PR DESCRIPTION
This is because the underlying nif function is:

pub fn decrypt_cipher(cipher_bytes: Vec<u8>, keypair: Keypair) -> Option<Vec<u8>> {

which gets encoded as nil when the option is empty