### PR TITLE
Murisi/rustler experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "arm"
 version = "0.5.0"
-source = "git+https://github.com/anoma/arm-risc0?branch=m1dnight%2Fsdk-integration#5ad87d2cb4583dd1e63b648717297cb00c8fb487"
+source = "git+https://github.com/anoma/arm-risc0?branch=murisi%2Fsdk-integration#08592fee80831e6da0880276d5321eb69e9d0f09"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "arm"
 version = "0.6.1"
-source = "git+https://github.com/anoma/arm-risc0.git?branch=jurevans%2Fpatch-keys-0.6.1#af43e5d659d3b5e0651c481b4aad137e8451ec44"
+source = "git+https://github.com/anoma/arm-risc0.git?branch=murisi%2Fpatch-keys-0.6.1#8857de2563979ec30e1bd48292984aaa4db0845a"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",
@@ -2828,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "evm_protocol_adapter_bindings"
 version = "1.0.0-beta"
-source = "git+https://github.com/anoma/evm-protocol-adapter?branch=feature%2Fsepolia-demo#ecd86b770b3997634471c09fd7e830ae2f8021c2"
+source = "git+https://github.com/anoma/evm-protocol-adapter?branch=murisi%2Fsepolia-demo#682b6ae5aa344a4c957d594603a0faa86378403f"
 dependencies = [
  "alloy",
  "arm 0.6.1",
@@ -5657,6 +5657,7 @@ dependencies = [
  "libloading",
  "regex-lite",
  "rustler_codegen",
+ "serde",
 ]
 
 [[package]]
@@ -6108,7 +6109,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 [[package]]
 name = "simple-transfer-app"
 version = "0.1.0"
-source = "git+https://github.com/anoma/arm-risc0.git?branch=jurevans%2Fpatch-keys-0.6.1#af43e5d659d3b5e0651c481b4aad137e8451ec44"
+source = "git+https://github.com/anoma/arm-risc0.git?branch=murisi%2Fpatch-keys-0.6.1#8857de2563979ec30e1bd48292984aaa4db0845a"
 dependencies = [
  "arm 0.6.1",
  "hex",
@@ -6122,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "simple-transfer-witness"
 version = "0.1.0"
-source = "git+https://github.com/anoma/arm-risc0.git?branch=jurevans%2Fpatch-keys-0.6.1#af43e5d659d3b5e0651c481b4aad137e8451ec44"
+source = "git+https://github.com/anoma/arm-risc0.git?branch=murisi%2Fpatch-keys-0.6.1#8857de2563979ec30e1bd48292984aaa4db0845a"
 dependencies = [
  "arm 0.6.1",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "arm"
 version = "0.5.0"
-source = "git+https://github.com/anoma/arm-risc0?branch=murisi%2Fsdk-integration#08592fee80831e6da0880276d5321eb69e9d0f09"
+source = "git+https://github.com/anoma/arm-risc0?branch=murisi%2Fsdk-integration#48b9fe970a5733401cb064095288d0eeb1af80dd"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",
@@ -1326,13 +1326,14 @@ dependencies = [
  "risc0-zkvm",
  "rustler",
  "serde",
+ "serde_bytes",
  "sha3",
 ]
 
 [[package]]
 name = "arm"
 version = "0.6.1"
-source = "git+https://github.com/anoma/arm-risc0.git?branch=murisi%2Fpatch-keys-0.6.1#8857de2563979ec30e1bd48292984aaa4db0845a"
+source = "git+https://github.com/anoma/arm-risc0.git?branch=murisi%2Fpatch-keys-0.6.1#05c30fb1522b27824c33652906150e794e38008b"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",
@@ -1345,6 +1346,7 @@ dependencies = [
  "rand 0.8.5",
  "risc0-zkvm",
  "serde",
+ "serde_bytes",
  "sha3",
 ]
 
@@ -1360,6 +1362,7 @@ dependencies = [
  "risc0-zkvm",
  "rustler",
  "serde",
+ "serde_bytes",
  "serde_json",
  "tracing-subscriber 0.3.20",
 ]
@@ -2828,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "evm_protocol_adapter_bindings"
 version = "1.0.0-beta"
-source = "git+https://github.com/anoma/evm-protocol-adapter?branch=murisi%2Fsepolia-demo#682b6ae5aa344a4c957d594603a0faa86378403f"
+source = "git+https://github.com/anoma/evm-protocol-adapter?branch=murisi%2Fsepolia-demo#e515579fbd2e9d0d71fe11179a24b90e797302bf"
 dependencies = [
  "alloy",
  "arm 0.6.1",
@@ -5938,6 +5941,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6109,7 +6122,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 [[package]]
 name = "simple-transfer-app"
 version = "0.1.0"
-source = "git+https://github.com/anoma/arm-risc0.git?branch=murisi%2Fpatch-keys-0.6.1#8857de2563979ec30e1bd48292984aaa4db0845a"
+source = "git+https://github.com/anoma/arm-risc0.git?branch=murisi%2Fpatch-keys-0.6.1#05c30fb1522b27824c33652906150e794e38008b"
 dependencies = [
  "arm 0.6.1",
  "hex",
@@ -6123,11 +6136,12 @@ dependencies = [
 [[package]]
 name = "simple-transfer-witness"
 version = "0.1.0"
-source = "git+https://github.com/anoma/arm-risc0.git?branch=murisi%2Fpatch-keys-0.6.1#8857de2563979ec30e1bd48292984aaa4db0845a"
+source = "git+https://github.com/anoma/arm-risc0.git?branch=murisi%2Fpatch-keys-0.6.1#05c30fb1522b27824c33652906150e794e38008b"
 dependencies = [
  "arm 0.6.1",
  "rand 0.8.5",
  "serde",
+ "serde_bytes",
 ]
 
 [[package]]

--- a/lib/arm/arm.ex
+++ b/lib/arm/arm.ex
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.Arm do
+defmodule Anoma.Arm do
   @moduledoc """
   I define a few functions to test the ARM repo NIF interface.
   """
@@ -7,15 +7,15 @@ defmodule AnomaSDK.Arm do
     otp_app: :anoma_sdk,
     crate: :arm_bindings
 
-  alias AnomaSDK.Arm.ComplianceInstance
-  alias AnomaSDK.Arm.ComplianceUnit
-  alias AnomaSDK.Arm.ComplianceWitness
-  alias AnomaSDK.Arm.DeltaProof
-  alias AnomaSDK.Arm.DeltaWitness
-  alias AnomaSDK.Arm.Keypair
-  alias AnomaSDK.Arm.LogicVerifier
-  alias AnomaSDK.Arm.LogicVerifierInputs
-  alias AnomaSDK.Arm.Transaction
+  alias Anoma.Arm.ComplianceInstance
+  alias Anoma.Arm.ComplianceUnit
+  alias Anoma.Arm.ComplianceWitness
+  alias Anoma.Arm.DeltaProof
+  alias Anoma.Arm.DeltaWitness
+  alias Anoma.Arm.Keypair
+  alias Anoma.Arm.LogicVerifier
+  alias Anoma.Arm.LogicVerifierInputs
+  alias Anoma.Arm.Transaction
 
   @doc """
   Generates a random private key (Scalar) and its corresponding public key (ProjectivePoint)

--- a/lib/arm/arm.ex
+++ b/lib/arm/arm.ex
@@ -3,16 +3,9 @@ defmodule AnomaSDK.Arm do
   I define a few functions to test the ARM repo NIF interface.
   """
 
-  mix_config = Mix.Project.config()
-  version = mix_config[:version]
-  github_url = mix_config[:package][:links]["GitHub"]
-
-  use RustlerPrecompiled,
+  use Rustler,
     otp_app: :anoma_sdk,
-    crate: :arm_bindings,
-    base_url: "#{github_url}/releases/download/v#{version}",
-    version: version,
-    force_build: System.get_env("BUILD_NATIVE") in ["1", "true"]
+    crate: :arm_bindings
 
   alias AnomaSDK.Arm.ComplianceInstance
   alias AnomaSDK.Arm.ComplianceUnit

--- a/lib/arm/arm_test.ex
+++ b/lib/arm/arm_test.ex
@@ -1,34 +1,27 @@
-defmodule AnomaSDK.Arm.Test do
+defmodule Anoma.Arm.Test do
   @moduledoc """
   I define a few functions to test the ARM repo NIF interface.
   """
 
-  mix_config = Mix.Project.config()
-  version = mix_config[:version]
-  github_url = mix_config[:package][:links]["GitHub"]
-
-  use RustlerPrecompiled,
+  use Rustler,
     otp_app: :anoma_sdk,
-    crate: :arm_bindings_test,
-    base_url: "#{github_url}/releases/download/v#{version}",
-    version: version,
-    force_build: System.get_env("BUILD_NATIVE") in ["1", "true"]
+    crate: :arm_bindings_test
 
-  alias AnomaSDK.Arm.Action
-  alias AnomaSDK.Arm.AppData
-  alias AnomaSDK.Arm.Ciphertext
-  alias AnomaSDK.Arm.ComplianceInstance
-  alias AnomaSDK.Arm.ComplianceUnit
-  alias AnomaSDK.Arm.ComplianceWitness
-  alias AnomaSDK.Arm.DeltaProof
-  alias AnomaSDK.Arm.DeltaWitness
-  alias AnomaSDK.Arm.ExpirableBlob
-  alias AnomaSDK.Arm.LogicVerifier
-  alias AnomaSDK.Arm.LogicVerifierInputs
-  alias AnomaSDK.Arm.MerklePath
-  alias AnomaSDK.Arm.MerkleTree
-  alias AnomaSDK.Arm.Resource
-  alias AnomaSDK.Arm.Transaction
+  alias Anoma.Arm.Action
+  alias Anoma.Arm.AppData
+  alias Anoma.Arm.Ciphertext
+  alias Anoma.Arm.ComplianceInstance
+  alias Anoma.Arm.ComplianceUnit
+  alias Anoma.Arm.ComplianceWitness
+  alias Anoma.Arm.DeltaProof
+  alias Anoma.Arm.DeltaWitness
+  alias Anoma.Arm.ExpirableBlob
+  alias Anoma.Arm.LogicVerifier
+  alias Anoma.Arm.LogicVerifierInputs
+  alias Anoma.Arm.MerklePath
+  alias Anoma.Arm.MerkleTree
+  alias Anoma.Arm.Resource
+  alias Anoma.Arm.Transaction
 
   # ----------------------------------------------------------------------------#
   #                                SecretKey                                    #

--- a/lib/arm/constants.ex
+++ b/lib/arm/constants.ex
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.Arm.Constants do
+defmodule Anoma.Arm.Constants do
   @moduledoc """
   I define a list of constants used in the Anoma resource machine.
   """

--- a/lib/arm/datastructures/action.ex
+++ b/lib/arm/datastructures/action.ex
@@ -1,13 +1,13 @@
-defmodule AnomaSDK.Arm.Action do
+defmodule Anoma.Arm.Action do
   @moduledoc """
   I define the datastructure `Action` that defines the structure of an action
   for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.Action
-  alias AnomaSDK.Arm.ComplianceUnit
-  alias AnomaSDK.Arm.LogicVerifierInputs
+  alias Anoma.Arm.Action
+  alias Anoma.Arm.ComplianceUnit
+  alias Anoma.Arm.LogicVerifierInputs
 
   typedstruct do
     @derive Jason.Encoder

--- a/lib/arm/datastructures/app_data.ex
+++ b/lib/arm/datastructures/app_data.ex
@@ -1,12 +1,12 @@
-defmodule AnomaSDK.Arm.AppData do
+defmodule Anoma.Arm.AppData do
   @moduledoc """
   I define the datastructure `AppData` that defines the structure of an app data
   for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.AppData
-  alias AnomaSDK.Arm.ExpirableBlob
+  alias Anoma.Arm.AppData
+  alias Anoma.Arm.ExpirableBlob
 
   typedstruct do
     @derive Jason.Encoder

--- a/lib/arm/datastructures/cipher_text.ex
+++ b/lib/arm/datastructures/cipher_text.ex
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.Arm.Ciphertext do
+defmodule Anoma.Arm.Ciphertext do
   @moduledoc """
   Defines the type for a Ciphertext, which is just a binary.
   """

--- a/lib/arm/datastructures/compliance_instance.ex
+++ b/lib/arm/datastructures/compliance_instance.ex
@@ -1,11 +1,11 @@
-defmodule AnomaSDK.Arm.ComplianceInstance do
+defmodule Anoma.Arm.ComplianceInstance do
   @moduledoc """
   I define the datastructure `ComplianceInstance` that defines the structure of
   a compliance instance for the resource machine.
   """
   use TypedStruct
-  use AnomaSDK.Arm.Inspect
-  alias AnomaSDK.Arm.ComplianceInstance
+  use Anoma.Arm.Inspect
+  alias Anoma.Arm.ComplianceInstance
 
   typedstruct do
     field :consumed_nullifier, binary()
@@ -30,6 +30,6 @@ defmodule AnomaSDK.Arm.ComplianceInstance do
 
   @spec from_map(map) :: t()
   def from_map(map) do
-    struct(ComplianceInstance, AnomaSDK.Json.decode_keys(map))
+    struct(ComplianceInstance, Anoma.Json.decode_keys(map))
   end
 end

--- a/lib/arm/datastructures/compliance_unit.ex
+++ b/lib/arm/datastructures/compliance_unit.ex
@@ -1,18 +1,18 @@
-defmodule AnomaSDK.Arm.ComplianceUnit do
+defmodule Anoma.Arm.ComplianceUnit do
   @moduledoc """
   I define the datastructure `ComplianceUnit` that defines the structure of a compliance unit for the resource machine.
   """
   use TypedStruct
-  alias AnomaSDK.Arm
-  alias AnomaSDK.Arm.ComplianceInstance
-  alias AnomaSDK.Arm.ComplianceUnit
+  alias Anoma.Arm
+  alias Anoma.Arm.ComplianceInstance
+  alias Anoma.Arm.ComplianceUnit
 
   typedstruct do
     field :instance, binary()
     field :proof, binary()
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.ComplianceUnit do
+  defimpl Jason.Encoder, for: Anoma.Arm.ComplianceUnit do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       struct
@@ -25,7 +25,7 @@ defmodule AnomaSDK.Arm.ComplianceUnit do
 
   @spec from_map(map) :: t()
   def from_map(map) do
-    struct(ComplianceUnit, AnomaSDK.Json.decode_keys(map))
+    struct(ComplianceUnit, Anoma.Json.decode_keys(map))
   end
 
   @doc """

--- a/lib/arm/datastructures/compliance_witness.ex
+++ b/lib/arm/datastructures/compliance_witness.ex
@@ -1,15 +1,15 @@
-defmodule AnomaSDK.Arm.ComplianceWitness do
+defmodule Anoma.Arm.ComplianceWitness do
   @moduledoc """
   I define the datastructure `DeltaWitness` that defines the structure of a delta witness for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.ComplianceWitness
-  alias AnomaSDK.Arm.MerklePath
-  alias AnomaSDK.Arm.NullifierKey
-  alias AnomaSDK.Arm.Resource
+  alias Anoma.Arm.ComplianceWitness
+  alias Anoma.Arm.MerklePath
+  alias Anoma.Arm.NullifierKey
+  alias Anoma.Arm.Resource
 
-  import AnomaSDK.Arm.Constants
+  import Anoma.Arm.Constants
 
   typedstruct do
     field(:consumed_resource, Resource.t())
@@ -20,12 +20,14 @@ defmodule AnomaSDK.Arm.ComplianceWitness do
     field(:rcv, binary())
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.ComplianceWitness do
+  defimpl Jason.Encoder, for: Anoma.Arm.ComplianceWitness do
     @spec encode(struct(), term()) :: term()
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       struct
-      |> AnomaSDK.Json.encode_keys([:ephemeral_root, :nf_key, :rcv])
+      |> Map.update(:nf_key, [], fn {:NullifierKey, x} -> x end)
+      |> Map.update(:merkle_path, [], fn {:MerklePath, x} -> x end)
+      |> Anoma.Json.encode_keys([:ephemeral_root, :nf_key, :rcv])
       |> Map.update!(:merkle_path, &MerklePath.to_map/1)
       |> Jason.Encode.map(opts)
     end
@@ -34,9 +36,10 @@ defmodule AnomaSDK.Arm.ComplianceWitness do
   @spec from_map(map) :: t()
   def from_map(map) do
     consumed_resource = Resource.from_map(map.consumed_resource)
-    merkle_path = MerklePath.from_map(map.merkle_path)
+    merkle_path = {:MerklePath, MerklePath.from_map(map.merkle_path)}
     created_resource = Resource.from_map(map.created_resource)
-    map = AnomaSDK.Json.decode_keys(map, [:ephemeral_root, :nf_key, :rcv])
+    map = Anoma.Json.decode_keys(map, [:ephemeral_root, :nf_key, :rcv])
+      |> Map.update(:nf_key, [], fn x -> {:NullifierKey, x} end)
 
     struct(ComplianceWitness, %{
       map

--- a/lib/arm/datastructures/delta_proof.ex
+++ b/lib/arm/datastructures/delta_proof.ex
@@ -1,27 +1,27 @@
-defmodule AnomaSDK.Arm.DeltaProof do
+defmodule Anoma.Arm.DeltaProof do
   @moduledoc """
   I define the datastructure `DeltaWitness` that defines the structure of a delta witness for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.DeltaProof
+  alias Anoma.Arm.DeltaProof
 
   typedstruct do
     field :signature, binary()
     field :recid, number()
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.DeltaProof do
+  defimpl Jason.Encoder, for: Anoma.Arm.DeltaProof do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       struct
-      |> AnomaSDK.Json.encode_keys([:signature])
+      |> Anoma.Json.encode_keys([:signature])
       |> Jason.Encode.map(opts)
     end
   end
 
   @spec from_map(map) :: t()
   def from_map(map) do
-    struct(DeltaProof, AnomaSDK.Json.decode_keys(map, [:signature]))
+    struct(DeltaProof, Anoma.Json.decode_keys(map, [:signature]))
   end
 end

--- a/lib/arm/datastructures/delta_witness.ex
+++ b/lib/arm/datastructures/delta_witness.ex
@@ -1,26 +1,26 @@
-defmodule AnomaSDK.Arm.DeltaWitness do
+defmodule Anoma.Arm.DeltaWitness do
   @moduledoc """
   I define the datastructure `DeltaWitness` that defines the structure of a delta witness for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.DeltaWitness
+  alias Anoma.Arm.DeltaWitness
 
   typedstruct do
     field :signing_key, binary()
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.DeltaWitness do
+  defimpl Jason.Encoder, for: Anoma.Arm.DeltaWitness do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       struct
-      |> AnomaSDK.Json.encode_keys([:signing_key])
+      |> Anoma.Json.encode_keys([:signing_key])
       |> Jason.Encode.map(opts)
     end
   end
 
   @spec from_map(map) :: t()
   def from_map(map) do
-    struct(DeltaWitness, AnomaSDK.Json.decode_keys(map))
+    struct(DeltaWitness, Anoma.Json.decode_keys(map))
   end
 end

--- a/lib/arm/datastructures/expirable_blob.ex
+++ b/lib/arm/datastructures/expirable_blob.ex
@@ -1,28 +1,28 @@
-defmodule AnomaSDK.Arm.ExpirableBlob do
+defmodule Anoma.Arm.ExpirableBlob do
   @moduledoc """
   I define the datastructure `ExpirableBlob` that defines the structure of an expirable blob
   for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.ExpirableBlob
+  alias Anoma.Arm.ExpirableBlob
 
   typedstruct do
     field :blob, binary()
-    field :deletion_criteria, number()
+    field :deletion_criterion, number()
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.ExpirableBlob do
+  defimpl Jason.Encoder, for: Anoma.Arm.ExpirableBlob do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       struct
-      |> AnomaSDK.Json.encode_keys([:blob])
+      |> Anoma.Json.encode_keys([:blob])
       |> Jason.Encode.map(opts)
     end
   end
 
   @spec from_map(map) :: t()
   def from_map(map) do
-    struct(ExpirableBlob, AnomaSDK.Json.decode_keys(map, [:blob]))
+    struct(ExpirableBlob, Anoma.Json.decode_keys(map, [:blob]))
   end
 end

--- a/lib/arm/datastructures/keypair.ex
+++ b/lib/arm/datastructures/keypair.ex
@@ -1,29 +1,29 @@
-defmodule AnomaSDK.Arm.Keypair do
+defmodule Anoma.Arm.Keypair do
   @moduledoc """
   I define the datastructure `Keypair` that holds a public key and a private key.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm
-  alias AnomaSDK.Arm.Keypair
+  alias Anoma.Arm
+  alias Anoma.Arm.Keypair
 
   typedstruct do
     field :secret_key, binary()
     field :public_key, binary()
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.Keypair do
+  defimpl Jason.Encoder, for: Anoma.Arm.Keypair do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       struct
-      |> AnomaSDK.Json.encode_keys([:secret_key, :public_key])
+      |> Anoma.Json.encode_keys([:secret_key, :public_key])
       |> Jason.Encode.map(opts)
     end
   end
 
   @spec from_map(map) :: t()
   def from_map(map) do
-    struct(Keypair, AnomaSDK.Json.decode_keys(map))
+    struct(Keypair, Anoma.Json.decode_keys(map))
   end
 
   @doc """

--- a/lib/arm/datastructures/logic_verifier.ex
+++ b/lib/arm/datastructures/logic_verifier.ex
@@ -1,9 +1,9 @@
-defmodule AnomaSDK.Arm.LogicVerifier do
+defmodule Anoma.Arm.LogicVerifier do
   @moduledoc """
   I define the datastructure `Resource` that defines the structure of a resource for the resource machine.
   """
   use TypedStruct
-  alias AnomaSDK.Arm.LogicVerifier
+  alias Anoma.Arm.LogicVerifier
 
   typedstruct do
     field :instance, binary()
@@ -11,17 +11,17 @@ defmodule AnomaSDK.Arm.LogicVerifier do
     field :verifying_key, binary()
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.LogicVerifier do
+  defimpl Jason.Encoder, for: Anoma.Arm.LogicVerifier do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       struct
-      |> AnomaSDK.Json.encode_keys()
+      |> Anoma.Json.encode_keys()
       |> Jason.Encode.map(opts)
     end
   end
 
   @spec from_map(map) :: t()
   def from_map(map) do
-    struct(LogicVerifier, AnomaSDK.Json.decode_keys(map))
+    struct(LogicVerifier, Anoma.Json.decode_keys(map))
   end
 end

--- a/lib/arm/datastructures/logic_verifier_inputs.ex
+++ b/lib/arm/datastructures/logic_verifier_inputs.ex
@@ -1,12 +1,12 @@
-defmodule AnomaSDK.Arm.LogicVerifierInputs do
+defmodule Anoma.Arm.LogicVerifierInputs do
   @moduledoc """
   I define the datastructure `LogicVerifierInput` that defines the structure of
   a logic verifier input for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.AppData
-  alias AnomaSDK.Arm.LogicVerifierInputs
+  alias Anoma.Arm.AppData
+  alias Anoma.Arm.LogicVerifierInputs
 
   typedstruct do
     field :tag, binary()
@@ -15,11 +15,11 @@ defmodule AnomaSDK.Arm.LogicVerifierInputs do
     field :proof, binary()
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.LogicVerifierInputs do
+  defimpl Jason.Encoder, for: Anoma.Arm.LogicVerifierInputs do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       struct
-      |> AnomaSDK.Json.encode_keys([:tag, :verifying_key, :proof])
+      |> Anoma.Json.encode_keys([:tag, :verifying_key, :proof])
       |> Jason.Encode.map(opts)
     end
   end
@@ -29,7 +29,7 @@ defmodule AnomaSDK.Arm.LogicVerifierInputs do
     map =
       map
       |> Map.update!(:app_data, &AppData.from_map(&1))
-      |> AnomaSDK.Json.decode_keys([:tag, :verifying_key, :proof])
+      |> Anoma.Json.decode_keys([:tag, :verifying_key, :proof])
 
     struct(LogicVerifierInputs, map)
   end

--- a/lib/arm/datastructures/merkle_path.ex
+++ b/lib/arm/datastructures/merkle_path.ex
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.Arm.MerklePath do
+defmodule Anoma.Arm.MerklePath do
   @moduledoc """
   I define the datastructure `MerklePath` that defines the structure of a merkle path.
   """

--- a/lib/arm/datastructures/merkle_tree.ex
+++ b/lib/arm/datastructures/merkle_tree.ex
@@ -1,12 +1,12 @@
-defmodule AnomaSDK.Arm.MerkleTree do
+defmodule Anoma.Arm.MerkleTree do
   @moduledoc """
   I define the datastructure `MerkleTree` that defines the structure of a merkle tree for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.Constants
-  alias AnomaSDK.Arm.MerklePath
-  alias AnomaSDK.Arm.MerkleTree
+  alias Anoma.Arm.Constants
+  alias Anoma.Arm.MerklePath
+  alias Anoma.Arm.MerkleTree
 
   import Bitwise
 
@@ -19,7 +19,7 @@ defmodule AnomaSDK.Arm.MerkleTree do
     field :leaves, [binary()]
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.MerkleTree do
+  defimpl Jason.Encoder, for: Anoma.Arm.MerkleTree do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       leaves = Enum.map(struct.leaves, &Base.encode64/1)

--- a/lib/arm/datastructures/nullifier_key.ex
+++ b/lib/arm/datastructures/nullifier_key.ex
@@ -1,11 +1,11 @@
-defmodule AnomaSDK.Arm.NullifierKey do
+defmodule Anoma.Arm.NullifierKey do
   @moduledoc """
   I define the datastructure `NullifierKey` that defines the structure of a nullifierkey for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.NullifierKey
-  alias AnomaSDK.Arm.NullifierKeyCommitment
+  alias Anoma.Arm.NullifierKey
+  alias Anoma.Arm.NullifierKeyCommitment
 
   @typedoc """
   The type of a nullifierkey.

--- a/lib/arm/datastructures/nullifier_key_commitment.ex
+++ b/lib/arm/datastructures/nullifier_key_commitment.ex
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.Arm.NullifierKeyCommitment do
+defmodule Anoma.Arm.NullifierKeyCommitment do
   @moduledoc """
   I define the datastructure `NullifierKeyCommitment` that defines the structure
   of a nullifierkey commitment for the resource machine.

--- a/lib/arm/datastructures/resource.ex
+++ b/lib/arm/datastructures/resource.ex
@@ -1,14 +1,14 @@
-defmodule AnomaSDK.Arm.Resource do
+defmodule Anoma.Arm.Resource do
   @moduledoc """
   I define the datastructure `Resource` that defines the structure of a resource for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.NullifierKey
-  alias AnomaSDK.Arm.NullifierKeyCommitment
-  alias AnomaSDK.Arm.Resource
+  alias Anoma.Arm.NullifierKey
+  alias Anoma.Arm.NullifierKeyCommitment
+  alias Anoma.Arm.Resource
 
-  import AnomaSDK.Util
+  import Anoma.Util
 
   typedstruct do
     field :logic_ref, binary()
@@ -21,11 +21,12 @@ defmodule AnomaSDK.Arm.Resource do
     field :rand_seed, binary(), default: :crypto.strong_rand_bytes(32)
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.Resource do
+  defimpl Jason.Encoder, for: Anoma.Arm.Resource do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       struct
-      |> AnomaSDK.Json.encode_keys([
+      |> Map.update(:nk_commitment, [], fn {:NullifierKeyCommitment, x} -> x end)
+      |> Anoma.Json.encode_keys([
         :logic_ref,
         :label_ref,
         :value_ref,
@@ -41,7 +42,7 @@ defmodule AnomaSDK.Arm.Resource do
   def from_map(map) do
     map =
       map
-      |> AnomaSDK.Json.decode_keys([
+      |> Anoma.Json.decode_keys([
         :logic_ref,
         :label_ref,
         :value_ref,
@@ -49,6 +50,7 @@ defmodule AnomaSDK.Arm.Resource do
         :rand_seed,
         :nk_commitment
       ])
+      |> Map.update(:nk_commitment, [], fn x -> {:NullifierKeyCommitment, x} end)
 
     struct(Resource, map)
   end

--- a/lib/arm/datastructures/transaction.ex
+++ b/lib/arm/datastructures/transaction.ex
@@ -1,14 +1,14 @@
-defmodule AnomaSDK.Arm.Transaction do
+defmodule Anoma.Arm.Transaction do
   @moduledoc """
   I define the datastructure `Transaction` that defines the structure of a transaction for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm
-  alias AnomaSDK.Arm.Action
-  alias AnomaSDK.Arm.DeltaProof
-  alias AnomaSDK.Arm.DeltaWitness
-  alias AnomaSDK.Arm.Transaction
+  alias Anoma.Arm
+  alias Anoma.Arm.Action
+  alias Anoma.Arm.DeltaProof
+  alias Anoma.Arm.DeltaWitness
+  alias Anoma.Arm.Transaction
 
   typedstruct do
     field :actions, [Action.t()], default: []
@@ -16,7 +16,7 @@ defmodule AnomaSDK.Arm.Transaction do
     field :expected_balance, binary(), default: <<>>
   end
 
-  defimpl Jason.Encoder, for: AnomaSDK.Arm.Transaction do
+  defimpl Jason.Encoder, for: Anoma.Arm.Transaction do
     @spec encode(struct(), term()) :: term()
     def encode(struct, opts) do
       delta_proof =
@@ -30,7 +30,7 @@ defmodule AnomaSDK.Arm.Transaction do
 
       struct
       |> Map.put(:delta_proof, delta_proof)
-      |> AnomaSDK.Json.encode_keys([:expected_balance])
+      |> Anoma.Json.encode_keys([:expected_balance])
       |> Jason.Encode.map(opts)
     end
   end
@@ -38,7 +38,7 @@ defmodule AnomaSDK.Arm.Transaction do
   @spec from_map(map) :: t()
   def from_map(map) do
     actions = Enum.map(map.actions, &Action.from_map/1)
-    map = AnomaSDK.Json.decode_keys(map, [:expected_balance])
+    map = Anoma.Json.decode_keys(map, [:expected_balance])
 
     delta_proof =
       case map.delta_proof do

--- a/lib/arm/datastructures/trivial_logic_witness.ex
+++ b/lib/arm/datastructures/trivial_logic_witness.ex
@@ -1,14 +1,14 @@
-defmodule AnomaSDK.Arm.TrivialLogicWitness do
+defmodule Anoma.Arm.TrivialLogicWitness do
   @moduledoc """
   I define the datastructure `TrivialLogicWitness` that defines the structure of a
   trivial logic witness for the resource machine.
   """
   use TypedStruct
 
-  alias AnomaSDK.Arm.MerklePath
-  alias AnomaSDK.Arm.NullifierKey
-  alias AnomaSDK.Arm.Resource
-  alias AnomaSDK.Arm.TrivialLogicWitness
+  alias Anoma.Arm.MerklePath
+  alias Anoma.Arm.NullifierKey
+  alias Anoma.Arm.Resource
+  alias Anoma.Arm.TrivialLogicWitness
 
   typedstruct do
     field :resource, Resource.t()

--- a/lib/arm/inspect.ex
+++ b/lib/arm/inspect.ex
@@ -1,10 +1,10 @@
-defmodule AnomaSDK.Arm.Inspect do
+defmodule Anoma.Arm.Inspect do
   @moduledoc """
   I define helpers for the inspect protocol for Anoma Arm structs.
   """
 
   import Inspect.Algebra
-  alias AnomaSDK.Arm.Inspect, as: I
+  alias Anoma.Arm.Inspect, as: I
 
   defmacro __using__(_opts) do
     quote do

--- a/lib/json.ex
+++ b/lib/json.ex
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.Json do
+defmodule Anoma.Json do
   @moduledoc """
   Contains various functions to deal with json data decoding and encoding.
   """

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.Util do
+defmodule Anoma.Util do
   @moduledoc """
   Various utility functions used in different modules in the SDK.
   """

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.MixProject do
+defmodule Anoma.MixProject do
   use Mix.Project
 
   @version "0.0.2"

--- a/native/arm_bindings/Cargo.toml
+++ b/native/arm_bindings/Cargo.toml
@@ -9,8 +9,8 @@ name = "arm_bindings"
 crate-type = ["cdylib"]
 
 [dependencies]
-evm_protocol_adapter_bindings = { git = "https://github.com/anoma/evm-protocol-adapter", branch = "feature/sepolia-demo" }
-arm = { git = "https://github.com/anoma/arm-risc0", branch = "m1dnight/sdk-integration", default-features = true, features = [
+evm_protocol_adapter_bindings = { git = "https://github.com/anoma/evm-protocol-adapter", branch = "murisi/sepolia-demo" }
+arm = { git = "https://github.com/anoma/arm-risc0", branch = "murisi/sdk-integration", default-features = true, features = [
     "nif",
     "transaction",
     "groth16_prover",
@@ -23,7 +23,7 @@ risc0-zkvm = { version = "3.0.3", features = [
     "unstable",
 ], default-features = false }
 
-rustler = "0.36.2"
+rustler = { version = "0.36.2", features = ["serde"] }
 serde = { version = "1.0.197", default-features = false }
 serde_json = "1.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/native/arm_bindings/Cargo.toml
+++ b/native/arm_bindings/Cargo.toml
@@ -25,6 +25,7 @@ risc0-zkvm = { version = "3.0.3", features = [
 
 rustler = { version = "0.36.2", features = ["serde"] }
 serde = { version = "1.0.197", default-features = false }
+serde_bytes = { version = "0.11.19", default-features = false }
 serde_json = "1.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 k256 = { version = "=0.13.3", features = [

--- a/native/arm_bindings/src/lib.rs
+++ b/native/arm_bindings/src/lib.rs
@@ -6,78 +6,45 @@ use arm::delta_proof::DeltaWitness;
 use arm::encryption::{random_keypair, Ciphertext, SecretKey};
 use arm::logic_proof::LogicVerifier;
 use arm::logic_proof::LogicVerifierInputs;
-use arm::rustler_util::{at_struct, RustlerDecoder, RustlerEncoder};
 use arm::transaction::Transaction;
 use k256::AffinePoint;
-use rustler::types::map::map_new;
-use rustler::{atoms, nif, Decoder, Encoder, Env, NifResult, Term};
+use rustler::{nif, SerdeTerm};
+use serde::{Deserialize, Serialize};
 
 /// A Keypair is a struct that holds a SecretKey and Affinepoint.
 /// It is used here to implement the Encoder and RusterEncoder trait.
 /// The encoded value is a tuple.
+#[derive(Deserialize, Serialize)]
 pub struct Keypair {
     pub secret: SecretKey,
     pub public: AffinePoint,
 }
 
-atoms! {
-    at_secret_key = "secret_key",
-    at_public_key = "public_key",
-    at_keypair_key = "Elixir.AnomaSDK.Arm.Keypair"
-}
-
-impl Encoder for Keypair {
-    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
-        let secret_key = self.secret.rustler_encode(env).unwrap();
-        let public_key = self.public.rustler_encode(env).unwrap();
-
-        let map = map_new(env)
-            .map_put(at_struct().encode(env), at_keypair_key())
-            .unwrap()
-            .map_put(at_secret_key(), secret_key)
-            .unwrap()
-            .map_put(at_public_key(), public_key);
-
-        map.expect("failed to encode Keypair")
-    }
-}
-
-impl<'a> Decoder<'a> for Keypair {
-    fn decode(term: Term<'a>) -> NifResult<Self> {
-        let secret_term = term.map_get(at_secret_key().encode(term.get_env()))?;
-        let secret: SecretKey = RustlerDecoder::rustler_decode(secret_term)?;
-
-        let public_term = term.map_get(at_public_key().encode(term.get_env()))?;
-        let public: AffinePoint = RustlerDecoder::rustler_decode(public_term)?;
-        Ok(Keypair { secret, public })
-    }
-}
-
 #[nif]
 /// Generates a random pair of SecretKey and AffinePoint.
-pub fn random_key_pair() -> Keypair {
+pub fn random_key_pair() -> SerdeTerm<Keypair> {
     let (secret, public) = random_keypair();
-    Keypair { secret, public }
+    SerdeTerm(Keypair { secret, public })
 }
 
 /// Returns the ComplianceInstance from within a ComplianceUnit
 #[nif]
-fn compliance_unit_instance(unit: ComplianceUnit) -> ComplianceInstance {
-    unit.get_instance()
+fn compliance_unit_instance(SerdeTerm(unit): SerdeTerm<ComplianceUnit>) -> SerdeTerm<ComplianceInstance> {
+    SerdeTerm(unit.get_instance())
 }
 
 #[nif]
-fn encrypt_cipher(cipher: Vec<u8>, keypair: Keypair, nonce: Vec<u8>) -> Ciphertext {
-    Ciphertext::encrypt(
+fn encrypt_cipher(cipher: Vec<u8>, SerdeTerm(keypair): SerdeTerm<Keypair>, nonce: Vec<u8>) -> SerdeTerm<Ciphertext> {
+    SerdeTerm(Ciphertext::encrypt(
         cipher.as_ref(),
         &keypair.public,
         &keypair.secret,
         nonce.try_into().expect("REASON"),
-    )
+    ))
 }
 
 #[nif]
-pub fn decrypt_cipher(cipher_bytes: Vec<u8>, keypair: Keypair) -> Option<Vec<u8>> {
+pub fn decrypt_cipher(cipher_bytes: Vec<u8>, SerdeTerm(keypair): SerdeTerm<Keypair>) -> Option<Vec<u8>> {
     let cipher_text = Ciphertext::from_bytes(cipher_bytes);
     let decipher_result = cipher_text.decrypt(&keypair.secret);
     decipher_result.ok()
@@ -85,34 +52,34 @@ pub fn decrypt_cipher(cipher_bytes: Vec<u8>, keypair: Keypair) -> Option<Vec<u8>
 
 #[nif]
 /// Generate a compliance unit from a compliance witness.
-fn prove_compliance_witness(compliance_witness: ComplianceWitness) -> ComplianceUnit {
-    ComplianceUnit::create(&compliance_witness)
+fn prove_compliance_witness(SerdeTerm(compliance_witness): SerdeTerm<ComplianceWitness>) -> SerdeTerm<ComplianceUnit> {
+    SerdeTerm(ComplianceUnit::create(&compliance_witness))
 }
 
 #[nif]
 /// Converts a logic verifier to a logic verifier inputs.
 /// this nif is here because this conversion relies on the Journal
 /// implementation of Risc0 ZKVM.
-fn convert(logic_verifier: LogicVerifier) -> LogicVerifierInputs {
-    logic_verifier.into()
+fn convert(SerdeTerm(logic_verifier): SerdeTerm<LogicVerifier>) -> SerdeTerm<LogicVerifierInputs> {
+    SerdeTerm(logic_verifier.into())
 }
 
 #[nif]
 /// Generate a proof for a delta witness.
-fn prove_delta_witness(witness: DeltaWitness, message: Vec<u8>) -> DeltaProof {
-    DeltaProof::prove(&message, &witness)
+fn prove_delta_witness(SerdeTerm(witness): SerdeTerm<DeltaWitness>, message: Vec<u8>) -> SerdeTerm<DeltaProof> {
+    SerdeTerm(DeltaProof::prove(&message, &witness))
 }
 
 #[nif]
 /// Given a transaction, puts in the delta proof.
-pub fn generate_delta_proof(transaction: Transaction) -> Transaction {
+pub fn generate_delta_proof(SerdeTerm(transaction): SerdeTerm<Transaction>) -> SerdeTerm<Transaction> {
     let mut tx = transaction.clone();
     tx.generate_delta_proof();
-    tx
+    SerdeTerm(tx)
 }
 
 #[nif]
-pub fn verify_transaction(transaction: Transaction) -> bool {
+pub fn verify_transaction(SerdeTerm(transaction): SerdeTerm<Transaction>) -> bool {
     transaction.verify()
 }
 

--- a/native/arm_bindings/src/lib.rs
+++ b/native/arm_bindings/src/lib.rs
@@ -10,12 +10,13 @@ use arm::transaction::Transaction;
 use k256::AffinePoint;
 use rustler::{nif, SerdeTerm};
 use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
 
 /// A Keypair is a struct that holds a SecretKey and Affinepoint.
 /// It is used here to implement the Encoder and RusterEncoder trait.
 /// The encoded value is a tuple.
 #[derive(Deserialize, Serialize)]
-#[serde(rename = "Elixir.AnomaSDK.Arm.Keypair")]
+#[serde(rename = "Elixir.Anoma.Arm.Keypair")]
 pub struct Keypair {
     #[serde(rename = "secret_key")]
     pub secret: SecretKey,
@@ -37,19 +38,18 @@ fn compliance_unit_instance(SerdeTerm(unit): SerdeTerm<ComplianceUnit>) -> Serde
 }
 
 #[nif]
-fn encrypt_cipher(SerdeTerm(cipher): SerdeTerm<Vec<u8>>, SerdeTerm(keypair): SerdeTerm<Keypair>, SerdeTerm(nonce): SerdeTerm<Vec<u8>>) -> SerdeTerm<Ciphertext> {
+fn encrypt_cipher(SerdeTerm(cipher): SerdeTerm<ByteBuf>, SerdeTerm(keypair): SerdeTerm<Keypair>, SerdeTerm(nonce): SerdeTerm<ByteBuf>) -> SerdeTerm<Ciphertext> {
     SerdeTerm(Ciphertext::encrypt(
-        cipher.as_ref(),
+        cipher.into_vec().as_ref(),
         &keypair.public,
         &keypair.secret,
-        nonce.try_into().expect("REASON"),
+        nonce.into_vec().try_into().expect("REASON"),
     ))
 }
 
 #[nif]
-pub fn decrypt_cipher(SerdeTerm(cipher_bytes): SerdeTerm<Vec<u8>>, SerdeTerm(keypair): SerdeTerm<Keypair>) -> SerdeTerm<Option<Vec<u8>>> {
-    let cipher_text = Ciphertext::from_bytes(cipher_bytes);
-    let decipher_result = cipher_text.decrypt(&keypair.secret);
+pub fn decrypt_cipher(SerdeTerm(cipher_text): SerdeTerm<Ciphertext>, SerdeTerm(keypair): SerdeTerm<Keypair>) -> SerdeTerm<Option<ByteBuf>> {
+    let decipher_result = cipher_text.decrypt(&keypair.secret).map(ByteBuf::from);
     SerdeTerm(decipher_result.ok())
 }
 
@@ -69,7 +69,7 @@ fn convert(SerdeTerm(logic_verifier): SerdeTerm<LogicVerifier>) -> SerdeTerm<Log
 
 #[nif]
 /// Generate a proof for a delta witness.
-fn prove_delta_witness(SerdeTerm(witness): SerdeTerm<DeltaWitness>, SerdeTerm(message): SerdeTerm<Vec<u8>>) -> SerdeTerm<DeltaProof> {
+fn prove_delta_witness(SerdeTerm(witness): SerdeTerm<DeltaWitness>, SerdeTerm(message): SerdeTerm<ByteBuf>) -> SerdeTerm<DeltaProof> {
     SerdeTerm(DeltaProof::prove(&message, &witness))
 }
 
@@ -86,4 +86,4 @@ pub fn verify_transaction(SerdeTerm(transaction): SerdeTerm<Transaction>) -> Ser
     SerdeTerm(transaction.verify())
 }
 
-rustler::init!("Elixir.AnomaSDK.Arm");
+rustler::init!("Elixir.Anoma.Arm");

--- a/native/arm_bindings/src/lib.rs
+++ b/native/arm_bindings/src/lib.rs
@@ -15,8 +15,11 @@ use serde::{Deserialize, Serialize};
 /// It is used here to implement the Encoder and RusterEncoder trait.
 /// The encoded value is a tuple.
 #[derive(Deserialize, Serialize)]
+#[serde(rename = "Elixir.AnomaSDK.Arm.Keypair")]
 pub struct Keypair {
+    #[serde(rename = "secret_key")]
     pub secret: SecretKey,
+    #[serde(rename = "public_key")]
     pub public: AffinePoint,
 }
 
@@ -34,7 +37,7 @@ fn compliance_unit_instance(SerdeTerm(unit): SerdeTerm<ComplianceUnit>) -> Serde
 }
 
 #[nif]
-fn encrypt_cipher(cipher: Vec<u8>, SerdeTerm(keypair): SerdeTerm<Keypair>, nonce: Vec<u8>) -> SerdeTerm<Ciphertext> {
+fn encrypt_cipher(SerdeTerm(cipher): SerdeTerm<Vec<u8>>, SerdeTerm(keypair): SerdeTerm<Keypair>, SerdeTerm(nonce): SerdeTerm<Vec<u8>>) -> SerdeTerm<Ciphertext> {
     SerdeTerm(Ciphertext::encrypt(
         cipher.as_ref(),
         &keypair.public,
@@ -44,10 +47,10 @@ fn encrypt_cipher(cipher: Vec<u8>, SerdeTerm(keypair): SerdeTerm<Keypair>, nonce
 }
 
 #[nif]
-pub fn decrypt_cipher(cipher_bytes: Vec<u8>, SerdeTerm(keypair): SerdeTerm<Keypair>) -> Option<Vec<u8>> {
+pub fn decrypt_cipher(SerdeTerm(cipher_bytes): SerdeTerm<Vec<u8>>, SerdeTerm(keypair): SerdeTerm<Keypair>) -> SerdeTerm<Option<Vec<u8>>> {
     let cipher_text = Ciphertext::from_bytes(cipher_bytes);
     let decipher_result = cipher_text.decrypt(&keypair.secret);
-    decipher_result.ok()
+    SerdeTerm(decipher_result.ok())
 }
 
 #[nif]
@@ -66,7 +69,7 @@ fn convert(SerdeTerm(logic_verifier): SerdeTerm<LogicVerifier>) -> SerdeTerm<Log
 
 #[nif]
 /// Generate a proof for a delta witness.
-fn prove_delta_witness(SerdeTerm(witness): SerdeTerm<DeltaWitness>, message: Vec<u8>) -> SerdeTerm<DeltaProof> {
+fn prove_delta_witness(SerdeTerm(witness): SerdeTerm<DeltaWitness>, SerdeTerm(message): SerdeTerm<Vec<u8>>) -> SerdeTerm<DeltaProof> {
     SerdeTerm(DeltaProof::prove(&message, &witness))
 }
 
@@ -79,8 +82,8 @@ pub fn generate_delta_proof(SerdeTerm(transaction): SerdeTerm<Transaction>) -> S
 }
 
 #[nif]
-pub fn verify_transaction(SerdeTerm(transaction): SerdeTerm<Transaction>) -> bool {
-    transaction.verify()
+pub fn verify_transaction(SerdeTerm(transaction): SerdeTerm<Transaction>) -> SerdeTerm<bool> {
+    SerdeTerm(transaction.verify())
 }
 
 rustler::init!("Elixir.AnomaSDK.Arm");

--- a/native/arm_bindings_test/Cargo.toml
+++ b/native/arm_bindings_test/Cargo.toml
@@ -9,7 +9,7 @@ name = "arm_bindings_test"
 crate-type = ["cdylib"]
 
 [dependencies]
-arm = { git = "https://github.com/anoma/arm-risc0", branch = "m1dnight/sdk-integration", default-features = true, features = ["nif"] }
+arm = { git = "https://github.com/anoma/arm-risc0", branch = "murisi/sdk-integration", default-features = true, features = ["nif"] }
 
 
 
@@ -18,7 +18,7 @@ risc0-zkvm = { version = "3.0.3", features = [
     "unstable",
 ], default-features = false }
 
-rustler = "0.36.2"
+rustler = { version = "0.36.2", features = ["serde"] }
 serde = { version = "1.0.197", default-features = false }
 serde_json = "1.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/native/arm_bindings_test/src/lib.rs
+++ b/native/arm_bindings_test/src/lib.rs
@@ -1,3 +1,3 @@
 mod test;
 
-rustler::init!("Elixir.AnomaSDK.Arm.Test");
+rustler::init!("Elixir.Anoma.Arm.Test");

--- a/native/arm_bindings_test/src/test.rs
+++ b/native/arm_bindings_test/src/test.rs
@@ -19,19 +19,19 @@ use k256::ecdsa::{RecoveryId, Signature, SigningKey};
 use k256::elliptic_curve::rand_core::OsRng;
 use rand::random;
 use risc0_zkvm::Digest;
-use rustler::nif;
+use rustler::{self, nif, SerdeTerm};
 
 //----------------------------------------------------------------------------//
 //                                SecretKey                                   //
 //----------------------------------------------------------------------------//
 
 #[nif]
-fn test_secret_key() -> SecretKey {
-    SecretKey::random()
+fn test_secret_key() -> SerdeTerm<SecretKey> {
+    SerdeTerm(SecretKey::random())
 }
 
 #[nif]
-fn test_secret_key(secret_key: SecretKey) -> SecretKey {
+fn test_secret_key(secret_key: SerdeTerm<SecretKey>) -> SerdeTerm<SecretKey> {
     secret_key
 }
 
@@ -40,12 +40,12 @@ fn test_secret_key(secret_key: SecretKey) -> SecretKey {
 //----------------------------------------------------------------------------//
 
 #[nif]
-fn test_cipher_text() -> Ciphertext {
-    Ciphertext::from_words(random_vector_u32(64).as_slice())
+fn test_cipher_text() -> SerdeTerm<Ciphertext> {
+    SerdeTerm(Ciphertext::from_words(random_vector_u32(64).as_slice()))
 }
 
 #[nif]
-fn test_cipher_text(cipher_text: Ciphertext) -> Ciphertext {
+fn test_cipher_text(cipher_text: SerdeTerm<Ciphertext>) -> SerdeTerm<Ciphertext> {
     cipher_text
 }
 
@@ -55,12 +55,12 @@ fn test_cipher_text(cipher_text: Ciphertext) -> Ciphertext {
 
 #[nif]
 /// Create an arbitrary ComplianceUnit and return it.
-fn test_compliance_unit() -> ComplianceUnit {
-    random_compliance_unit()
+fn test_compliance_unit() -> SerdeTerm<ComplianceUnit> {
+    SerdeTerm(random_compliance_unit())
 }
 
 #[nif]
-fn test_compliance_unit(compliance_unit: ComplianceUnit) -> ComplianceUnit {
+fn test_compliance_unit(compliance_unit: SerdeTerm<ComplianceUnit>) -> SerdeTerm<ComplianceUnit> {
     compliance_unit
 }
 
@@ -70,12 +70,12 @@ fn test_compliance_unit(compliance_unit: ComplianceUnit) -> ComplianceUnit {
 
 #[nif]
 /// Create arbitrary expirable blob and return it.
-fn test_expirable_blob() -> ExpirableBlob {
-    random_epxirable_blob()
+fn test_expirable_blob() -> SerdeTerm<ExpirableBlob> {
+    SerdeTerm(random_epxirable_blob())
 }
 
 #[nif]
-fn test_expirable_blob(expirable_blob: ExpirableBlob) -> ExpirableBlob {
+fn test_expirable_blob(expirable_blob: SerdeTerm<ExpirableBlob>) -> SerdeTerm<ExpirableBlob> {
     expirable_blob
 }
 
@@ -85,12 +85,12 @@ fn test_expirable_blob(expirable_blob: ExpirableBlob) -> ExpirableBlob {
 
 #[nif]
 /// Create arbitrary appdata and return it.
-fn test_app_data() -> AppData {
-    random_app_data()
+fn test_app_data() -> SerdeTerm<AppData> {
+    SerdeTerm(random_app_data())
 }
 
 #[nif]
-fn test_app_data(app_data: AppData) -> AppData {
+fn test_app_data(app_data: SerdeTerm<AppData>) -> SerdeTerm<AppData> {
     app_data
 }
 
@@ -100,12 +100,12 @@ fn test_app_data(app_data: AppData) -> AppData {
 
 #[nif]
 /// Create arbitrary app data and return it.
-fn test_logic_verifier_inputs() -> LogicVerifierInputs {
-    random_logic_verifier_inputs()
+fn test_logic_verifier_inputs() -> SerdeTerm<LogicVerifierInputs> {
+    SerdeTerm(random_logic_verifier_inputs())
 }
 
 #[nif]
-fn test_logic_verifier_inputs(logic_verifier_inputs: LogicVerifierInputs) -> LogicVerifierInputs {
+fn test_logic_verifier_inputs(logic_verifier_inputs: SerdeTerm<LogicVerifierInputs>) -> SerdeTerm<LogicVerifierInputs> {
     logic_verifier_inputs
 }
 
@@ -115,12 +115,12 @@ fn test_logic_verifier_inputs(logic_verifier_inputs: LogicVerifierInputs) -> Log
 
 #[nif]
 /// Create an arbitrary action and return it.
-fn test_action() -> Action {
-    random_action()
+fn test_action() -> SerdeTerm<Action> {
+    SerdeTerm(random_action())
 }
 
 #[nif]
-fn test_action(action: Action) -> Action {
+fn test_action(action: SerdeTerm<Action>) -> SerdeTerm<Action> {
     action
 }
 
@@ -130,12 +130,12 @@ fn test_action(action: Action) -> Action {
 
 #[nif]
 /// Create a default merkle tree.
-fn test_merkle_tree() -> MerkleTree {
-    MerkleTree::new(vec![random_digest(), random_digest()])
+fn test_merkle_tree() -> SerdeTerm<MerkleTree> {
+    SerdeTerm(MerkleTree::new(vec![random_digest(), random_digest()]))
 }
 
 #[nif]
-fn test_merkle_tree(merkle_tree: MerkleTree) -> MerkleTree {
+fn test_merkle_tree(merkle_tree: SerdeTerm<MerkleTree>) -> SerdeTerm<MerkleTree> {
     merkle_tree
 }
 //----------------------------------------------------------------------------//
@@ -144,12 +144,12 @@ fn test_merkle_tree(merkle_tree: MerkleTree) -> MerkleTree {
 
 #[nif]
 /// Create a default merkle path.
-fn test_merkle_path() -> MerklePath {
-    random_merkle_path()
+fn test_merkle_path() -> SerdeTerm<MerklePath> {
+    SerdeTerm(random_merkle_path())
 }
 
 #[nif]
-fn test_merkle_path(merkle_path: MerklePath) -> MerklePath {
+fn test_merkle_path(merkle_path: SerdeTerm<MerklePath>) -> SerdeTerm<MerklePath> {
     merkle_path
 }
 
@@ -159,13 +159,13 @@ fn test_merkle_path(merkle_path: MerklePath) -> MerklePath {
 
 #[nif]
 /// Create an arbitrary ComplianceInstance and return it.
-fn test_compliance_instance() -> ComplianceInstance {
-    random_compliance_instance()
+fn test_compliance_instance() -> SerdeTerm<ComplianceInstance> {
+    SerdeTerm(random_compliance_instance())
 }
 
 #[nif]
 /// Return the ComplianceInstance.
-fn test_compliance_instance(compliance_instance: ComplianceInstance) -> ComplianceInstance {
+fn test_compliance_instance(compliance_instance: SerdeTerm<ComplianceInstance>) -> SerdeTerm<ComplianceInstance> {
     compliance_instance
 }
 
@@ -175,12 +175,12 @@ fn test_compliance_instance(compliance_instance: ComplianceInstance) -> Complian
 
 #[nif]
 /// Create an arbitrary compliance witness and return it.
-fn test_compliance_witness() -> ComplianceWitness {
-    random_compliance_witness()
+fn test_compliance_witness() -> SerdeTerm<ComplianceWitness> {
+    SerdeTerm(random_compliance_witness())
 }
 
 #[nif]
-fn test_compliance_witness(compliance_witness: ComplianceWitness) -> ComplianceWitness {
+fn test_compliance_witness(compliance_witness: SerdeTerm<ComplianceWitness>) -> SerdeTerm<ComplianceWitness> {
     compliance_witness
 }
 
@@ -190,14 +190,14 @@ fn test_compliance_witness(compliance_witness: ComplianceWitness) -> ComplianceW
 
 #[nif]
 /// Create arbitrary nullifier key commitment and return it.
-fn test_nullifier_key_commitment() -> NullifierKeyCommitment {
-    random_nullifier_key_commitment()
+fn test_nullifier_key_commitment() -> SerdeTerm<NullifierKeyCommitment> {
+    SerdeTerm(random_nullifier_key_commitment())
 }
 
 #[nif]
 fn test_nullifier_key_commitment(
-    nullifier_key_commitment: NullifierKeyCommitment,
-) -> NullifierKeyCommitment {
+    nullifier_key_commitment: SerdeTerm<NullifierKeyCommitment>,
+) -> SerdeTerm<NullifierKeyCommitment> {
     nullifier_key_commitment
 }
 
@@ -207,12 +207,12 @@ fn test_nullifier_key_commitment(
 
 #[nif]
 /// Create an arbitrary nullifier key and return it.
-fn test_nullifier_key() -> NullifierKey {
-    random_nullifier_key()
+fn test_nullifier_key() -> SerdeTerm<NullifierKey> {
+    SerdeTerm(random_nullifier_key())
 }
 
 #[nif]
-fn test_nullifier_key(nullifier_key: NullifierKey) -> NullifierKey {
+fn test_nullifier_key(nullifier_key: SerdeTerm<NullifierKey>) -> SerdeTerm<NullifierKey> {
     nullifier_key
 }
 
@@ -222,12 +222,12 @@ fn test_nullifier_key(nullifier_key: NullifierKey) -> NullifierKey {
 
 #[nif]
 /// Create an arbitrary resource and return it.
-fn test_resource() -> Resource {
-    random_resource()
+fn test_resource() -> SerdeTerm<Resource> {
+    SerdeTerm(random_resource())
 }
 
 #[nif]
-fn test_resource(resource: Resource) -> Resource {
+fn test_resource(resource: SerdeTerm<Resource>) -> SerdeTerm<Resource> {
     resource
 }
 
@@ -237,12 +237,12 @@ fn test_resource(resource: Resource) -> Resource {
 
 #[nif]
 /// Create arbitrary delta proof and return it.
-fn test_delta_proof() -> DeltaProof {
-    random_delta_proof()
+fn test_delta_proof() -> SerdeTerm<DeltaProof> {
+    SerdeTerm(random_delta_proof())
 }
 
 #[nif]
-fn test_delta_proof(delta_proof: DeltaProof) -> DeltaProof {
+fn test_delta_proof(delta_proof: SerdeTerm<DeltaProof>) -> SerdeTerm<DeltaProof> {
     delta_proof
 }
 
@@ -252,12 +252,12 @@ fn test_delta_proof(delta_proof: DeltaProof) -> DeltaProof {
 
 #[nif]
 /// Create a random delta witness to return from the NIF.
-fn test_delta_witness() -> DeltaWitness {
-    random_delta_witness()
+fn test_delta_witness() -> SerdeTerm<DeltaWitness> {
+    SerdeTerm(random_delta_witness())
 }
 
 #[nif]
-fn test_delta_witness(delta_witness: DeltaWitness) -> DeltaWitness {
+fn test_delta_witness(delta_witness: SerdeTerm<DeltaWitness>) -> SerdeTerm<DeltaWitness> {
     delta_witness
 }
 
@@ -266,12 +266,12 @@ fn test_delta_witness(delta_witness: DeltaWitness) -> DeltaWitness {
 //----------------------------------------------------------------------------//
 
 #[nif]
-fn test_logic_verifier() -> LogicVerifier {
-    random_logic_verifier()
+fn test_logic_verifier() -> SerdeTerm<LogicVerifier> {
+    SerdeTerm(random_logic_verifier())
 }
 
 #[nif]
-fn test_logic_verifier(logic_verifier: LogicVerifier) -> LogicVerifier {
+fn test_logic_verifier(logic_verifier: SerdeTerm<LogicVerifier>) -> SerdeTerm<LogicVerifier> {
     logic_verifier
 }
 
@@ -281,12 +281,12 @@ fn test_logic_verifier(logic_verifier: LogicVerifier) -> LogicVerifier {
 
 #[nif]
 /// Create an arbitrary transaction and return it.
-fn test_transaction() -> Transaction {
-    random_transaction()
+fn test_transaction() -> SerdeTerm<Transaction> {
+    SerdeTerm(random_transaction())
 }
 
 #[nif]
-fn test_transaction(transaction: Transaction) -> Transaction {
+fn test_transaction(transaction: SerdeTerm<Transaction>) -> SerdeTerm<Transaction> {
     transaction
 }
 
@@ -296,23 +296,23 @@ fn test_transaction(transaction: Transaction) -> Transaction {
 
 #[nif]
 /// Create a Delta with a witness.
-fn test_delta_with_witness() -> Delta {
-    Delta::Witness(random_delta_witness())
+fn test_delta_with_witness() -> SerdeTerm<Delta> {
+    SerdeTerm(Delta::Witness(random_delta_witness()))
 }
 
 #[nif]
-fn test_delta_with_witness(delta: Delta) -> Delta {
+fn test_delta_with_witness(delta: SerdeTerm<Delta>) -> SerdeTerm<Delta> {
     delta
 }
 
 #[nif]
 /// Create a Delta with a proof.
-fn test_delta_with_proof() -> Delta {
-    Delta::Proof(random_delta_proof())
+fn test_delta_with_proof() -> SerdeTerm<Delta> {
+    SerdeTerm(Delta::Proof(random_delta_proof()))
 }
 
 #[nif]
-fn test_delta_with_proof(delta: Delta) -> Delta {
+fn test_delta_with_proof(delta: SerdeTerm<Delta>) -> SerdeTerm<Delta> {
     delta
 }
 

--- a/test/anoma_test.exs
+++ b/test/anoma_test.exs
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.Test do
+defmodule Anoma.Test do
   use ExUnit.Case
   doctest Anoma
 end

--- a/test/json_encoding_roundtrip_test.exs
+++ b/test/json_encoding_roundtrip_test.exs
@@ -1,20 +1,20 @@
-defmodule AnomaSDK.Test.JSONRoundtripTest do
+defmodule Anoma.Test.JSONRoundtripTest do
   use ExUnit.Case
 
-  alias AnomaSDK.Arm.Action
-  alias AnomaSDK.Arm.AppData
-  alias AnomaSDK.Arm.ComplianceInstance
-  alias AnomaSDK.Arm.ComplianceUnit
-  alias AnomaSDK.Arm.ComplianceWitness
-  alias AnomaSDK.Arm.DeltaProof
-  alias AnomaSDK.Arm.DeltaWitness
-  alias AnomaSDK.Arm.ExpirableBlob
-  alias AnomaSDK.Arm.LogicVerifier
-  alias AnomaSDK.Arm.LogicVerifierInputs
-  alias AnomaSDK.Arm.MerkleTree
-  alias AnomaSDK.Arm.Resource
-  alias AnomaSDK.Arm.Test
-  alias AnomaSDK.Arm.Transaction
+  alias Anoma.Arm.Action
+  alias Anoma.Arm.AppData
+  alias Anoma.Arm.ComplianceInstance
+  alias Anoma.Arm.ComplianceUnit
+  alias Anoma.Arm.ComplianceWitness
+  alias Anoma.Arm.DeltaProof
+  alias Anoma.Arm.DeltaWitness
+  alias Anoma.Arm.ExpirableBlob
+  alias Anoma.Arm.LogicVerifier
+  alias Anoma.Arm.LogicVerifierInputs
+  alias Anoma.Arm.MerkleTree
+  alias Anoma.Arm.Resource
+  alias Anoma.Arm.Test
+  alias Anoma.Arm.Transaction
 
   describe "JSON roundtrip tests" do
     test "Action - encode to JSON, decode back, and convert with from_map" do
@@ -27,7 +27,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = Action.from_map(decoded_map)
@@ -46,7 +46,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = AppData.from_map(decoded_map)
@@ -65,7 +65,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = ComplianceInstance.from_map(decoded_map)
@@ -84,7 +84,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = ComplianceUnit.from_map(decoded_map)
@@ -103,7 +103,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = ComplianceWitness.from_map(decoded_map)
@@ -122,7 +122,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = DeltaProof.from_map(decoded_map)
@@ -141,7 +141,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = DeltaWitness.from_map(decoded_map)
@@ -160,7 +160,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = ExpirableBlob.from_map(decoded_map)
@@ -179,7 +179,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = LogicVerifier.from_map(decoded_map)
@@ -198,7 +198,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = LogicVerifierInputs.from_map(decoded_map)
@@ -217,7 +217,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = MerkleTree.from_map(decoded_map)
@@ -236,7 +236,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
       decoded_map =
         json_string
         |> Jason.decode!()
-        |> AnomaSDK.Json.keys_to_atoms()
+        |> Anoma.Json.keys_to_atoms()
 
       # Convert map back to struct using from_map
       recovered = Resource.from_map(decoded_map)
@@ -256,7 +256,7 @@ defmodule AnomaSDK.Test.JSONRoundtripTest do
     decoded_map =
       json_string
       |> Jason.decode!()
-      |> AnomaSDK.Json.keys_to_atoms()
+      |> Anoma.Json.keys_to_atoms()
 
     # Convert map back to struct using from_map
     recovered = Transaction.from_map(decoded_map)

--- a/test/native/arm_test.exs
+++ b/test/native/arm_test.exs
@@ -1,4 +1,4 @@
-defmodule AnomaSDK.Test.Native.ArmTest do
+defmodule Anoma.Test.Native.ArmTest do
   @moduledoc """
   This module tests the test NIF bindings from the `native/arm_test` repo.
 
@@ -7,44 +7,44 @@ defmodule AnomaSDK.Test.Native.ArmTest do
   """
   use ExUnit.Case
 
-  alias AnomaSDK.Arm.Action
-  alias AnomaSDK.Arm.AppData
-  alias AnomaSDK.Arm.ComplianceInstance
-  alias AnomaSDK.Arm.ComplianceUnit
-  alias AnomaSDK.Arm.ComplianceWitness
-  alias AnomaSDK.Arm.ExpirableBlob
-  alias AnomaSDK.Arm.Keypair
-  alias AnomaSDK.Arm.LogicVerifier
-  alias AnomaSDK.Arm.LogicVerifierInputs
-  alias AnomaSDK.Arm.MerkleTree
-  alias AnomaSDK.Arm.Resource
-  alias AnomaSDK.Arm.Test
-  alias AnomaSDK.Arm.Transaction
+  alias Anoma.Arm.Action
+  alias Anoma.Arm.AppData
+  alias Anoma.Arm.ComplianceInstance
+  alias Anoma.Arm.ComplianceUnit
+  alias Anoma.Arm.ComplianceWitness
+  alias Anoma.Arm.ExpirableBlob
+  alias Anoma.Arm.Keypair
+  alias Anoma.Arm.LogicVerifier
+  alias Anoma.Arm.LogicVerifierInputs
+  alias Anoma.Arm.MerkleTree
+  alias Anoma.Arm.Resource
+  alias Anoma.Arm.Test
+  alias Anoma.Arm.Transaction
 
   test "verify ciphertext encrypt and decrypt" do
     # generate a keypair to encrypt a cipher
-    sender_keypair = AnomaSDK.Arm.random_key_pair()
-    receiver_keypair = AnomaSDK.Arm.random_key_pair()
+    sender_keypair = Anoma.Arm.random_key_pair()
+    receiver_keypair = Anoma.Arm.random_key_pair()
     # data to encrypt
     cipher = :crypto.strong_rand_bytes(32)
     # nonce
     nonce = :crypto.strong_rand_bytes(12)
 
     encrypted =
-      AnomaSDK.Arm.encrypt_cipher(
+      Anoma.Arm.encrypt_cipher(
         cipher,
         %Keypair{secret_key: sender_keypair.secret_key, public_key: receiver_keypair.public_key},
         nonce
       )
 
-    AnomaSDK.Arm.decrypt_cipher(encrypted, receiver_keypair)
+    Anoma.Arm.decrypt_cipher(encrypted, receiver_keypair)
   end
 
   # ----------------------------------------------------------------------------#
   #                                SecretKey                                   #
   # ----------------------------------------------------------------------------#
 
-  defp verify_secret_key_types(secret_key) do
+  defp verify_secret_key_types({:SecretKey, secret_key}) do
     assert is_binary(secret_key)
   end
 
@@ -65,7 +65,7 @@ defmodule AnomaSDK.Test.Native.ArmTest do
   #                                Ciphertext                                   #
   # ----------------------------------------------------------------------------#
 
-  defp verify_cipher_text_types(cipher_text) do
+  defp verify_cipher_text_types({:Ciphertext, cipher_text}) do
     assert is_binary(cipher_text)
   end
 
@@ -115,7 +115,7 @@ defmodule AnomaSDK.Test.Native.ArmTest do
   defp verify_expirable_blob_types(expirable_blob) do
     assert %ExpirableBlob{} = expirable_blob
     assert is_binary(expirable_blob.blob)
-    assert is_number(expirable_blob.deletion_criteria)
+    assert is_number(expirable_blob.deletion_criterion)
   end
 
   describe "expirable blob" do
@@ -266,7 +266,7 @@ defmodule AnomaSDK.Test.Native.ArmTest do
   #                                MerklePath                                   #
   # ----------------------------------------------------------------------------#
 
-  defp verify_merkle_path_types(merkle_path) do
+  defp verify_merkle_path_types({:MerklePath, merkle_path}) do
     # assert type
     assert is_list(merkle_path)
 
@@ -330,7 +330,7 @@ defmodule AnomaSDK.Test.Native.ArmTest do
   #                                NullifierKeyCommitment                       #
   # ----------------------------------------------------------------------------#
 
-  defp verify_nullifier_key_commitment_types(nf_key_commitment) do
+  defp verify_nullifier_key_commitment_types({:NullifierKeyCommitment, nf_key_commitment}) do
     assert is_binary(nf_key_commitment)
   end
 
@@ -351,20 +351,20 @@ defmodule AnomaSDK.Test.Native.ArmTest do
   #                                NullifierKey                                 #
   # ----------------------------------------------------------------------------#
 
-  defp verify_nullifier_key_types(nf_key) do
+  defp verify_nullifier_key_types({:NullifierKey, nf_key}) do
     assert is_binary(nf_key)
   end
 
   describe "nullifier key" do
     test "test_nullifier_key/0" do
-      nf_key = Test.test_nullifier_key()
+      {:NullifierKey, nf_key} = Test.test_nullifier_key()
       assert is_binary(nf_key)
     end
 
     test "test_nullifier_key/1" do
-      nf_key = Test.test_nullifier_key()
-      nf_key_return = Test.test_nullifier_key(nf_key)
-      assert nf_key == nf_key_return
+      nf_key = {:NullifierKey, nf_key_inner} = Test.test_nullifier_key()
+      {:NullifierKey, nf_key_return} = Test.test_nullifier_key(nf_key)
+      assert nf_key_inner == nf_key_return
       assert is_binary(nf_key_return)
     end
   end
@@ -375,7 +375,7 @@ defmodule AnomaSDK.Test.Native.ArmTest do
 
   defp verify_resource_types(resource) do
     # assert struct
-    assert %Resource{} = resource
+    assert %Resource{nk_commitment: {:NullifierKeyCommitment, nk_commitment_inner}} = resource
 
     # assert types
     assert is_binary(resource.logic_ref)
@@ -384,7 +384,7 @@ defmodule AnomaSDK.Test.Native.ArmTest do
     assert is_binary(resource.value_ref)
     assert is_boolean(resource.is_ephemeral)
     assert is_binary(resource.nonce)
-    assert is_binary(resource.nk_commitment)
+    assert is_binary(nk_commitment_inner)
     assert is_binary(resource.rand_seed)
   end
 

--- a/test/native/arm_test.exs
+++ b/test/native/arm_test.exs
@@ -32,12 +32,12 @@ defmodule AnomaSDK.Test.Native.ArmTest do
 
     encrypted =
       AnomaSDK.Arm.encrypt_cipher(
-        :binary.bin_to_list(cipher),
+        cipher,
         %Keypair{secret_key: sender_keypair.secret_key, public_key: receiver_keypair.public_key},
-        :binary.bin_to_list(nonce)
+        nonce
       )
 
-    AnomaSDK.Arm.decrypt_cipher(:binary.bin_to_list(encrypted), receiver_keypair)
+    AnomaSDK.Arm.decrypt_cipher(encrypted, receiver_keypair)
   end
 
   # ----------------------------------------------------------------------------#


### PR DESCRIPTION
Removed manual Rustler encoding/decoding implementations in favour of `SerdeTerm`s. (`SerdeTerm`s automatically provide Rustler encoders/decoders when given Serde serialization/deserialization implementations.) This PR depends upon https://github.com/rusterlium/rustler/pull/708 , which fixes decoding Elixir binary terms to Rust `Vec<u8>`s.